### PR TITLE
escape code in plugin template

### DIFF
--- a/djangocms_highlightjs/templates/djangocms_highlightjs/code.html
+++ b/djangocms_highlightjs/templates/djangocms_highlightjs/code.html
@@ -13,5 +13,5 @@
 {% endaddtoblock %}
 <pre id="highlight-{{ instance.pk }}" class="highlight-js">
 	{% if instance.filename %}<strong>{{ instance.filename }}</strong>{% endif %}
-	<code>{{ instance.body|safe }}</code>
+	<code>{{ instance.body }}</code>
 </pre>


### PR DESCRIPTION
I'm not sure why you've used the `safe` filter here @yakky - if you include the html-script tags e.g. like this:

``` html
<script type="text/javascript">
console.log('test');
</script>
```

the plugin will not be properly escaped and even executed by the client's browser
