### PR TITLE
Removing 'unicode_literals' from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 
 import djangocms_highlightjs
 


### PR DESCRIPTION
Removing 'unicode_literals' from __future__ import due to distutils errors on python 2.7